### PR TITLE
[deploy] Front Dockerfile v2.0

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN npm run build
+RUN NODE_OPTIONS=--max_old_space_size=4096 npm run build
 CMD ["npm", "run", "serve"]
 
 # Production stage


### PR DESCRIPTION
npm 빌드 중 리소스 사용량이 커서 빌드가 중지되는 에러